### PR TITLE
Keep reference to EnchantBroker when Dicts are live

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -13,4 +13,4 @@ jobs:
     - name: Build
       run: nix-shell --run "cargo build --verbose"
     - name: Run tests
-      run: nix-shell --run "cargo test --verbose"
+      run: nix-shell --run "env G_DEBUG=fatal-warnings cargo test --verbose"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### v0.3.0 (unreleased)
+* Fixed premature freeing of Broker (https://github.com/patronus-checker/enchant-rs/issues/4).
+* Minor **BC break**: Broker no longer implements `Drop` trait, it was moved to internal reference-counted value. (https://github.com/patronus-checker/enchant-rs/pull/5).
+
 ### v0.2.0 (2019-05-22)
 * Ported to Enchant 2.0.
 

--- a/shell.nix
+++ b/shell.nix
@@ -21,4 +21,10 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     enchant
   ];
+
+  XDG_DATA_DIRS =
+    with pkgs;
+    lib.makeSearchPath "share" [
+      hunspellDicts.en-us
+    ];
 }

--- a/tests/4-retain-broker.rs
+++ b/tests/4-retain-broker.rs
@@ -1,0 +1,21 @@
+struct Foo {
+    pub dict: enchant::Dict,
+}
+
+impl Foo {
+    fn new() -> Self {
+        let mut broker = enchant::Broker::new();
+        let dict = broker.request_dict("en_US").unwrap();
+        Self { dict }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_foo() {
+        let _foo = Foo::new();
+    }
+}


### PR DESCRIPTION
Modelled after the C++ bindings, the library assumed that the `EnchantBroker` will live for the whole lifetime of the `EnchantDict`s created by it. This is not a safe assumption to make.

If the `EnchantBroker` were freed but the `EnchantDict` were still live, it would produce a warning. And what is worse, the Dict’s broker field would then point to dead memory, potentially causing issues during memory consolidation.

To make it safe, we started wrapping the EnchantBroker pointer in Rc.

This solution is ugly and unidiomatic – it would likely be better to utilize Rust’s ownership system – but I am not that familiar with Rust and this workaround is easy enough.

Works around: https://github.com/patronus-checker/enchant-rs/issues/4
